### PR TITLE
Upgrade to 8.10.1

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@
 ELASTIC_PASSWORD=changeme
 
 # Version of Elastic products
-STACK_VERSION=8.8.1
+STACK_VERSION=8.10.1
 
 # Set the cluster name
 CLUSTER_NAME=docker-cluster

--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 
 # Elasticsearch Client Java Sample project
 
-https://discuss.elastic.co has many questions about the Elasticsearch Java Client.
+I'm getting a lot of questions on https://discuss.elastic.co where
+people are asking about the Elasticsearch Java Client.
 
-To address those questions, I often attempt to reproduce the issues.
+The only way to answer is by trying to reproduce the problems.
 
-This repository houses many examples derived from those discussions.
-I believe it could be beneficial for many, so I've made the code available here.
+This repository contains then some examples that are coming from those
+discussions. It might be useful for anyone, so I'm sharing the code here.
 
-You're welcome to contribute your own examples if you'd like.
+Feel free to add your own examples if you wish.
 
 This repository is tested against Elasticsearch 8.10.1.
 

--- a/README.md
+++ b/README.md
@@ -2,15 +2,14 @@
 
 # Elasticsearch Client Java Sample project
 
-I'm getting a lot of questions on https://discuss.elastic.co where
-people are asking about the Elasticsearch Java Client.
+https://discuss.elastic.co has many questions about the Elasticsearch Java Client.
 
-The only way to answer is by trying to reproduce the problems.
+To address those questions, I often attempt to reproduce the issues.
 
-This repository contains then some examples that are coming from those
-discussions. It might be useful for anyone, so I'm sharing the code here.
+This repository houses many examples derived from those discussions.
+I believe it could be beneficial for many, so I've made the code available here.
 
-Feel free to add your own examples if you wish.
+You're welcome to contribute your own examples if you'd like.
 
 This repository is tested against Elasticsearch 8.10.1.
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,16 @@
 
 # Elasticsearch Client Java Sample project
 
-I'm getting a lot of questions on https://discuss.elastic.co where
-people are asking about the Elasticsearch Java Client.
+https://discuss.elastic.co has many questions about the Elasticsearch Java Client.
 
-The only way to answer is by trying to reproduce the problems.
+To address those questions, I often attempt to reproduce the issues.
 
-This repository contains then some examples that are coming from those
-discussions. It might be useful for anyone, so I'm sharing the code here.
+This repository houses many examples derived from those discussions.
+I believe it could be beneficial for many, so I've made the code available here.
 
-Feel free to add your own examples if you wish.
+You're welcome to contribute your own examples if you'd like.
 
-This repository is tested against Elasticsearch 8.8.1.
+This repository is tested against Elasticsearch 8.10.1.
 
 ## Start a local cluster
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: "2.2"
+version: "2.3"
 
 services:
   setup:
@@ -56,6 +56,9 @@ services:
       - esdata01:/usr/share/elasticsearch/data
     ports:
       - ${ES_PORT}:9200
+    # now you could see the indexes by using https://localhost:9200/_cat/indices (user id: elastic, password: changeme)
+    expose:
+      - 9200
     environment:
       - node.name=es01
       - cluster.name=${CLUSTER_NAME}

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <!-- Main dependencies -->
-        <elasticsearch.version>8.8.1</elasticsearch.version>
+        <elasticsearch.version>8.10.1</elasticsearch.version>
         <jackson.version>2.15.1</jackson.version>
         <log4j.version>2.20.0</log4j.version>
         <slf4j.version>2.0.7</slf4j.version>
@@ -55,7 +55,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.1.2</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/documentation/README.md
+++ b/src/main/documentation/README.md
@@ -2,15 +2,14 @@
 
 # Elasticsearch Client Java Sample project
 
-I'm getting a lot of questions on https://discuss.elastic.co where
-people are asking about the Elasticsearch Java Client.
+https://discuss.elastic.co has many questions about the Elasticsearch Java Client.
 
-The only way to answer is by trying to reproduce the problems.
+To address those questions, I often attempt to reproduce the issues.
 
-This repository contains then some examples that are coming from those
-discussions. It might be useful for anyone, so I'm sharing the code here.
+This repository houses many examples derived from those discussions.
+I believe it could be beneficial for many, so I've made the code available here.
 
-Feel free to add your own examples if you wish.
+You're welcome to contribute your own examples if you'd like.
 
 This repository is tested against Elasticsearch ${elasticsearch.version}.
 


### PR DESCRIPTION
Here's the list of changes:

README.md modified a bit
upgraded Elastic to 8.10.1
exposed port 8200 for users to observe the indexes, documents, etc.

ran all tests and all are succesful.